### PR TITLE
Fix package name to com.example.studymate

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.attendanceapp">
+    package="com.example.studymate">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -15,17 +15,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name="com.example.studymate.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".AttendanceActivity" />
-        <activity android:name=".TaskManagerActivity" />
-        <activity android:name=".StudyMaterialActivity" />
-        <activity android:name=".ChatActivity" />
-        <activity android:name=".AIChatbotActivity" />
+        <activity android:name="com.example.studymate.AttendanceActivity" />
+        <activity android:name="com.example.studymate.TaskManagerActivity" />
+        <activity android:name="com.example.studymate.StudyMaterialActivity" />
+        <activity android:name="com.example.studymate.ChatActivity" />
+        <activity android:name="com.example.studymate.AIChatbotActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">College Attendance System</string>
+    <string name="app_name">StudyMate</string>
     <string name="attendance_title">Mark Attendance</string>
     <string name="mark_attendance_button">Mark Attendance</string>
     <string name="task_manager_title">Task Manager</string>


### PR DESCRIPTION
Update package name and activity references in AndroidManifest.xml and strings.xml.

* **AndroidManifest.xml**
  - Change package name from `com.example.attendanceapp` to `com.example.studymate`.
  - Update `android:name` attributes for activities to use the new package name.

* **strings.xml**
  - Change `app_name` string from "College Attendance System" to "StudyMate".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NavneetSingh-WD/StudyMate/pull/1?shareId=ff42fa7e-f487-4e49-8ba7-aa95c235585b).