### PR TITLE
Fix Android Studio configuration for StudyMate project

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
 
 android {
     compileSdkVersion 30

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'StudyMate'
+include ':app'


### PR DESCRIPTION
Add necessary configuration files and update `app/build.gradle` to make the Android app module selectable in Android Studio.

* **Add `settings.gradle`**
  - Set the root project name to `StudyMate`
  - Include the `app` module in the project

* **Add `build.gradle`**
  - Add the buildscript block with repositories and dependencies
  - Add the allprojects block with repositories

* **Update `app/build.gradle`**
  - Replace `apply plugin` with `plugins` block
  - Add `id 'com.android.application'` and `id 'kotlin-android'` plugins

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NavneetSingh-WD/StudyMate/pull/8?shareId=b752278c-0353-4adc-8e4e-3abe23fba022).